### PR TITLE
🧹 Refactor: Extract duplicated SEO Meta Tags into BaseMeta component

### DIFF
--- a/src/components/BaseMeta.astro
+++ b/src/components/BaseMeta.astro
@@ -1,0 +1,40 @@
+---
+import { SITE } from "@/consts"
+
+type Props = {
+  title: string
+  description: string
+  canonical: URL
+  ogImage: URL
+  type?: string
+  imageWidth?: string
+  imageHeight?: string
+}
+
+const {
+  title,
+  description,
+  canonical,
+  ogImage,
+  type = "website",
+  imageWidth = "1200",
+  imageHeight = "628",
+} = Astro.props
+---
+
+<meta property="og:title" content={title}>
+<meta property="og:description" content={description}>
+<meta property="og:url" content={canonical}>
+<meta property="og:type" content={type}>
+<meta property="og:site_name" content={SITE.title}>
+<meta property="og:locale" content={SITE.locale.replace("-", "_")}>
+<meta property="og:image" content={ogImage}>
+<meta property="og:image:width" content={imageWidth}>
+<meta property="og:image:height" content={imageHeight}>
+<meta property="og:image:alt" content={title}>
+
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content={title}>
+<meta name="twitter:description" content={description}>
+<meta name="twitter:image" content={ogImage}>
+<meta name="twitter:image:alt" content={title}>

--- a/src/components/MetaPage.astro
+++ b/src/components/MetaPage.astro
@@ -2,6 +2,7 @@
 import { SITE } from "@/consts"
 import { pageTitle } from "@/lib/content"
 import { normalizePath } from "@/lib/utils"
+import BaseMeta from "./BaseMeta.astro"
 
 type Props = {
   title?: string
@@ -24,19 +25,9 @@ const ogImage = new URL(SITE.defaultPageImage, base)
 <link rel="canonical" href={canonical}>
 {noindex && <meta name="robots" content="noindex, follow" />}
 
-<meta property="og:title" content={ogTitle}>
-<meta property="og:description" content={description}>
-<meta property="og:url" content={canonical}>
-<meta property="og:type" content="website">
-<meta property="og:site_name" content={SITE.title}>
-<meta property="og:locale" content={SITE.locale.replace("-", "_")}>
-<meta property="og:image" content={ogImage}>
-<meta property="og:image:width" content="1200">
-<meta property="og:image:height" content="628">
-<meta property="og:image:alt" content={ogTitle}>
-
-<meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content={ogTitle}>
-<meta name="twitter:description" content={description}>
-<meta name="twitter:image" content={ogImage}>
-<meta name="twitter:image:alt" content={ogTitle}>
+<BaseMeta
+  title={ogTitle}
+  description={description}
+  canonical={canonical}
+  ogImage={ogImage}
+/>

--- a/src/components/MetaPost.astro
+++ b/src/components/MetaPost.astro
@@ -3,6 +3,7 @@ import { SITE } from "@/consts"
 import { pageTitle } from "@/lib/content"
 import { normalizePath } from "@/lib/utils"
 import type { CollectionEntry } from "astro:content"
+import BaseMeta from "./BaseMeta.astro"
 
 type Props = {
   post: CollectionEntry<"blog">
@@ -26,22 +27,15 @@ const imageHeight = image?.height ?? 628
 <meta name="author" content={SITE.author}>
 <link rel="canonical" href={canonical}>
 
-<meta property="og:title" content={title}>
-<meta property="og:description" content={description}>
-<meta property="og:type" content="article">
-<meta property="og:url" content={canonical}>
-<meta property="og:site_name" content={SITE.title}>
-<meta property="og:locale" content={SITE.locale.replace("-", "_")}>
-<meta property="og:image" content={ogImage}>
-<meta property="og:image:width" content={String(imageWidth)}>
-<meta property="og:image:height" content={String(imageHeight)}>
-<meta property="og:image:alt" content={title}>
-
-<meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content={title}>
-<meta name="twitter:description" content={description}>
-<meta name="twitter:image" content={ogImage}>
-<meta name="twitter:image:alt" content={title}>
+<BaseMeta
+  title={title}
+  description={description}
+  canonical={canonical}
+  ogImage={ogImage}
+  type="article"
+  imageWidth={String(imageWidth)}
+  imageHeight={String(imageHeight)}
+/>
 
 <meta property="article:published_time" content={date.toISOString()}>
 <meta property="article:author" content={authorUrl}>


### PR DESCRIPTION
🎯 **What:** Extracted duplicated OpenGraph and Twitter SEO meta tags from `MetaPage.astro` and `MetaPost.astro` into a single reusable `<BaseMeta />` component.
💡 **Why:** This significantly improves codebase maintainability and readability by deduplicating boilerplate metadata across multiple Astro components.
✅ **Verification:** Verified that the project builds successfully (`pnpm run build`), formatted files (`pnpm run format`), and preserved the existing meta tag configurations and logic completely.
✨ **Result:** A cleaner implementation with a unified `BaseMeta` component, resolving the code health issue.

---
*PR created automatically by Jules for task [3466096643999455332](https://jules.google.com/task/3466096643999455332) started by @Fadyio*