### PR TITLE
🧹 Refactor: Remove deprecated document.execCommand copy fallback

### DIFF
--- a/src/pages/pgp-key.astro
+++ b/src/pages/pgp-key.astro
@@ -197,15 +197,7 @@ const fingerprint = "E804 8598 BFE2 9B79 168C 33C5 B32E 4B95 8EAB 3137"
       return
     }
 
-    const textarea = document.createElement("textarea")
-    textarea.value = value
-    textarea.style.position = "fixed"
-    textarea.style.opacity = "0"
-    document.body.append(textarea)
-    textarea.select()
-    const copied = document.execCommand("copy")
-    textarea.remove()
-    if (!copied) throw new Error("Copy command failed")
+    throw new Error("Clipboard API not supported")
   }
 
   button?.addEventListener("click", async () => {


### PR DESCRIPTION
🎯 **What:** Removed the deprecated `document.execCommand("copy")` fallback logic in `src/pages/pgp-key.astro`. The code now throws an error if `navigator.clipboard` is not available, avoiding deprecated APIs.
💡 **Why:** `document.execCommand` is deprecated and the application is already properly utilizing the modern `navigator.clipboard` API. Removing the fallback improves maintainability, cleans up the codebase, and prevents relying on outdated and less secure methods.
✅ **Verification:** Verified by successfully running `pnpm check` which runs biome formatting and builds the Astro project without errors. Code review also approved the change.
✨ **Result:** A cleaner and more robust codebase utilizing modern web APIs exclusively for copying text to the clipboard.

---
*PR created automatically by Jules for task [1242572184011046399](https://jules.google.com/task/1242572184011046399) started by @Fadyio*