### PR TITLE
🔒 Fix allowDangerousHtml security vulnerability in callouts

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@expressive-code/plugin-line-numbers": "^0.42.0",
     "astro": "^7.1.1",
     "github-slugger": "^2.0.0",
+    "hast-util-from-html": "^2.0.3",
     "hast-util-select": "^6.0.4",
     "hast-util-to-html": "^9.0.5",
     "hastscript": "^9.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       github-slugger:
         specifier: ^2.0.0
         version: 2.0.0
+      hast-util-from-html:
+        specifier: ^2.0.3
+        version: 2.0.3
       hast-util-select:
         specifier: ^6.0.4
         version: 6.0.4

--- a/src/lib/callout.ts
+++ b/src/lib/callout.ts
@@ -3,6 +3,7 @@ import { dirname, join } from "node:path"
 import { fileURLToPath } from "node:url"
 import type { ElementContent } from "hast"
 import type {} from "mdast-util-to-hast"
+import { fromHtml } from "hast-util-from-html"
 import { toHtml } from "hast-util-to-html"
 import { h } from "hastscript"
 import { defineMdastPlugin } from "satteri"
@@ -12,11 +13,14 @@ const ICONS_DIR = join(
   "../assets/icons/callouts",
 )
 
-const loadIcon = (name: string) =>
-  readFileSync(join(ICONS_DIR, `${name}.svg`), "utf8")
+const loadIcon = (name: string) => {
+  const svgString = readFileSync(join(ICONS_DIR, `${name}.svg`), "utf8")
     .replace("<svg", '<svg aria-hidden="true"')
     .replace(/\s+/g, " ")
     .trim()
+  return fromHtml(svgString, { space: "svg", fragment: true })
+    .children[0] as ElementContent
+}
 
 const VARIANTS: Record<string, string> = {
   note: "info-circle",
@@ -26,15 +30,12 @@ const VARIANTS: Record<string, string> = {
   important: "bell",
 }
 
-const icons: Record<string, string> = {}
+const icons: Record<string, ElementContent> = {}
 for (const name of [...new Set(Object.values(VARIANTS)), "alt-arrow-down"]) {
   icons[name] = loadIcon(name)
 }
 
 const capitalize = (s: string) => s.charAt(0).toUpperCase() + s.slice(1)
-
-const raw = (value: string): ElementContent =>
-  ({ type: "raw", value }) as unknown as ElementContent
 
 export const calloutDirective = defineMdastPlugin({
   name: "callout-directive",
@@ -56,11 +57,10 @@ export const calloutDirective = defineMdastPlugin({
 
     const summary = toHtml(
       h("summary", [
-        raw(icons[iconName]),
+        icons[iconName],
         h("span", title),
-        raw(icons["alt-arrow-down"]),
+        icons["alt-arrow-down"],
       ]),
-      { allowDangerousHtml: true },
     )
 
     const closed = !!node.attributes && "closed" in node.attributes


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
Insecure use of `allowDangerousHtml: true` in `src/lib/callout.ts` has been eliminated by safely parsing SVGs to a HAST AST using `hast-util-from-html` before rendering them.

⚠️ **Risk:** The potential impact if left unfixed
While the usage was currently scoped to local, trusted SVG strings, relying on `allowDangerousHtml: true` in a markdown processor introduces a severe security hygiene risk. It risks rendering arbitrary HTML if user inputs are incorrectly sanitized before processing, leading to Cross-Site Scripting (XSS).

🛡️ **Solution:** How the fix addresses the vulnerability
Instead of treating stringified SVG files as raw strings and enabling `allowDangerousHtml`, the solution uses `hast-util-from-html` to parse the SVGs securely into an AST representation once during initialization. It then directly builds the HTML structure using these parsed AST nodes. This allows for disabling `allowDangerousHtml: true` entirely from the `toHtml` transformation.

---
*PR created automatically by Jules for task [11791503298540262977](https://jules.google.com/task/11791503298540262977) started by @Fadyio*