### PR TITLE
🧹 Refactor card styling to shared CSS class

### DIFF
--- a/src/components/BlogCard.astro
+++ b/src/components/BlogCard.astro
@@ -12,7 +12,7 @@ const { post, headingLevel = 2 } = Astro.props
 const Heading = `h${headingLevel}` as "h2" | "h3"
 ---
 
-<li>
+<li class="card">
   {post.data.image && (
     <a href={`/blog/${post.id}`} tabindex="-1" aria-hidden="true">
       <Image src={post.data.image} alt="" width={640} height={336} />
@@ -38,25 +38,6 @@ const Heading = `h${headingLevel}` as "h2" | "h3"
 
 <style>
   li {
-    display: flex;
-    align-items: flex-start;
-    gap: var(--space-s);
-    padding: var(--space-s);
-    background-color: var(--surface);
-    border: 1px solid var(--border);
-    border-radius: var(--radius-xl);
-
-    > a {
-      flex-shrink: 0;
-      inline-size: 14rem;
-
-      :global(img) {
-        inline-size: 100%;
-        block-size: auto;
-        border-radius: var(--radius-lg);
-      }
-    }
-
     entry-info {
       display: flex;
       min-inline-size: 0;
@@ -106,15 +87,6 @@ const Heading = `h${headingLevel}` as "h2" | "h3"
 
       p {
         color: var(--muted-foreground);
-      }
-    }
-
-    @media (width < 40rem) {
-      flex-direction: column;
-
-      > a {
-        inline-size: 100%;
-        max-inline-size: 32rem;
       }
     }
   }

--- a/src/components/ProjectCard.astro
+++ b/src/components/ProjectCard.astro
@@ -11,7 +11,7 @@ const { name, description, link, tags, image, startDate, endDate } =
   project.data
 ---
 
-<li>
+<li class="card">
   {image && (
     <a
       href={link}
@@ -61,25 +61,6 @@ const { name, description, link, tags, image, startDate, endDate } =
 
 <style>
   li {
-    display: flex;
-    align-items: flex-start;
-    gap: var(--space-s);
-    padding: var(--space-s);
-    background-color: var(--surface);
-    border: 1px solid var(--border);
-    border-radius: var(--radius-xl);
-
-    > a {
-      flex-shrink: 0;
-      inline-size: 14rem;
-
-      :global(img) {
-        inline-size: 100%;
-        block-size: auto;
-        border-radius: var(--radius-lg);
-      }
-    }
-
     entry-info {
       display: flex;
       min-inline-size: 0;
@@ -149,15 +130,6 @@ const { name, description, link, tags, image, startDate, endDate } =
           background-color: color-mix(in oklab, var(--muted) 50%, transparent);
           border-radius: var(--radius-full);
         }
-      }
-    }
-
-    @media (width < 40rem) {
-      flex-direction: column;
-
-      > a {
-        inline-size: 100%;
-        max-inline-size: 32rem;
       }
     }
   }

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -12,6 +12,7 @@ import "@/styles/callout.css"
 import "@/styles/layout.css"
 import "@/styles/icon-button.css"
 import "@/styles/shape.css"
+import "@/styles/card.css"
 
 import Footer from "@/components/Footer.astro"
 import Header from "@/components/Header.astro"

--- a/src/styles/card.css
+++ b/src/styles/card.css
@@ -1,0 +1,29 @@
+.card {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-s);
+  padding: var(--space-s);
+  background-color: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-xl);
+
+  > a {
+    flex-shrink: 0;
+    inline-size: 14rem;
+
+    img {
+      inline-size: 100%;
+      block-size: auto;
+      border-radius: var(--radius-lg);
+    }
+  }
+
+  @media (width < 40rem) {
+    flex-direction: column;
+
+    > a {
+      inline-size: 100%;
+      max-inline-size: 32rem;
+    }
+  }
+}


### PR DESCRIPTION
🎯 **What:** Extracted duplicated card CSS for the `<li>` layout from `BlogCard.astro` and `ProjectCard.astro` into a shared `src/styles/card.css` file.
💡 **Why:** Reduces CSS duplication across components and improves code maintainability.
✅ **Verification:** Verified that `pnpm build` completes successfully and that formatting is correct. Also visually verified via a playwright script that both the blog card on the homepage and project card on the projects page maintain identical styling without any layout breakage.
✨ **Result:** A cleaner codebase with shared card layout styles.

---
*PR created automatically by Jules for task [7055963427221923542](https://jules.google.com/task/7055963427221923542) started by @Fadyio*